### PR TITLE
fix: 修改 drake-juejin 主题 .code-tooltip 文字颜色

### DIFF
--- a/drake-juejin.css
+++ b/drake-juejin.css
@@ -628,6 +628,10 @@ kbd {
     margin-top: 0 !important;
 }
 
+#write .code-tooltip {
+    color: grey;
+}
+
 .mathjax-block > .code-tooltip {
     bottom: .375rem;
 }


### PR DESCRIPTION
原先的 code-tooltip 文字颜色为黑色，背景颜色也为黑色，无法看到文字内容，因此将文字颜色修改成灰色。